### PR TITLE
Update to Ruby 2.3.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@
 
 source "https://rubygems.org"
 
-ruby "2.0.0"
+ruby "2.3.1"
 
 gem "scraperwiki", git: "https://github.com/openaustralia/scraperwiki-ruby.git", branch: "morph_defaults"
 gem "poltergeist"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -88,7 +88,7 @@ DEPENDENCIES
   scraperwiki!
 
 RUBY VERSION
-   ruby 2.0.0p353
+   ruby 2.3.1p112
 
 BUNDLED WITH
    1.12.5


### PR DESCRIPTION
I want to update Capybara and Poltergeist to the latest version to work
around a bug in Poltergeist where it's crashing when `.reset!` is called.

Newer version of Capybara depend on Rack 2.0+, and that version of Rack
requires a Ruby newer than 2.0.
